### PR TITLE
Add user info and etymology to JSON export

### DIFF
--- a/src/export/models.rs
+++ b/src/export/models.rs
@@ -75,6 +75,8 @@ pub struct DictionaryEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub etymology: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub jargon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub collection_note: Option<String>,

--- a/src/export/service.rs
+++ b/src/export/service.rs
@@ -1619,7 +1619,7 @@ async fn generate_json(
 
     let query = format!(
         "SELECT v.word, vbg.definitionid, c.rafsi, c.selmaho, c.definition,
-                c.notes, d.jargon, t.descriptor{}, u.username, u.realname,
+                c.notes, d.etymology, d.jargon, t.descriptor{}, u.username, u.realname,
                 (SELECT COALESCE(SUM(value), 0) FROM definitionvotes WHERE definitionid = vbg.definitionid) as score
          FROM valsibestguesses vbg
          JOIN valsi v ON v.valsiid = vbg.valsiid
@@ -1662,6 +1662,7 @@ async fn generate_json(
                 selmaho: row.get("selmaho"),
                 definition: row.get("definition"),
                 notes: row.get("notes"),
+                etymology: row.get("etymology"),
                 jargon: row.get("jargon"),
                 collection_note: row.get("collection_note"),
                 score: row.get("score"),


### PR DESCRIPTION
As explained in the commits, this adds user data and etymology info to the JSON dumps. The utility of a word's etymology should be apparent.

User data are important when doing programatic analysis as they can act as an origin and quality signal.  For example "krtisfranks" indicates this is likely a math word, and "dalgimbehe" indicates the word came from a team effort.  This is already public record, and these were included in the JVS dump.