### PR TITLE
Adds user name, real name, and etymology to JSON export

### DIFF
--- a/src/export/models.rs
+++ b/src/export/models.rs
@@ -55,6 +55,13 @@ pub struct ExportOptions {
 }
 
 #[derive(Serialize)]
+pub struct User {
+    pub username: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub realname: Option<String>,
+}
+
+#[derive(Serialize)]
 pub struct DictionaryEntry {
     pub word: String,
     pub word_type: String,
@@ -76,6 +83,8 @@ pub struct DictionaryEntry {
     pub gloss_keywords: Option<Vec<KeywordMapping>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub place_keywords: Option<Vec<KeywordMapping>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user: Option<User>,
 }
 
 #[derive(Debug, Serialize, Deserialize, ToSchema)]

--- a/src/export/models.rs
+++ b/src/export/models.rs
@@ -75,6 +75,8 @@ pub struct DictionaryEntry {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub notes: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub etymology: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub jargon: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub collection_note: Option<String>,

--- a/src/export/service.rs
+++ b/src/export/service.rs
@@ -17,6 +17,7 @@ use super::models::CachedExport;
 use super::models::CollectionExportItem;
 use super::models::DictionaryEntry;
 use super::models::NaturalEntry;
+use super::models::User;
 use super::models::ValsiRow;
 use super::models::{ExportFormat, ExportOptions};
 use crate::jbovlaste::KeywordMapping;

--- a/src/export/service.rs
+++ b/src/export/service.rs
@@ -1619,13 +1619,14 @@ async fn generate_json(
 
     let query = format!(
         "SELECT v.word, vbg.definitionid, c.rafsi, c.selmaho, c.definition,
-                c.notes, d.jargon, t.descriptor{},
+                c.notes, d.jargon, t.descriptor{}, u.username, u.realname,
                 (SELECT COALESCE(SUM(value), 0) FROM definitionvotes WHERE definitionid = vbg.definitionid) as score
          FROM valsibestguesses vbg
          JOIN valsi v ON v.valsiid = vbg.valsiid
          JOIN convenientdefinitions c ON c.definitionid = vbg.definitionid
          JOIN definitions d ON d.definitionid = vbg.definitionid
          JOIN valsitypes t ON t.typeid = v.typeid
+         LEFT JOIN users u ON u.userid = d.userid
          {}
          WHERE vbg.langid = $1 {} {}
          AND v.source_langid = 1
@@ -1666,6 +1667,10 @@ async fn generate_json(
                 score: row.get("score"),
                 gloss_keywords: gloss_map.get(&definition_id).cloned(),
                 place_keywords: place_map.get(&definition_id).cloned(),
+                user: row.get("username").map(|user| User {
+                    username: user,
+                    realname: row.get("realname"),
+                }),
             }
         })
         .collect();

--- a/src/export/service.rs
+++ b/src/export/service.rs
@@ -1619,7 +1619,7 @@ async fn generate_json(
 
     let query = format!(
         "SELECT v.word, vbg.definitionid, c.rafsi, c.selmaho, c.definition,
-                c.notes, d.jargon, t.descriptor{}, u.username, u.realname,
+                c.notes, d.etymology, d.jargon, t.descriptor{}, u.username, u.realname,
                 (SELECT COALESCE(SUM(value), 0) FROM definitionvotes WHERE definitionid = vbg.definitionid) as score
          FROM valsibestguesses vbg
          JOIN valsi v ON v.valsiid = vbg.valsiid
@@ -1662,6 +1662,7 @@ async fn generate_json(
                 selmaho: row.get("selmaho"),
                 definition: row.get("definition"),
                 notes: row.get("notes"),
+                etymology: row.get("etymology"),
                 jargon: row.get("jargon"),
                 collection_note: row.get("collection_note"),
                 score: row.get("score"),


### PR DESCRIPTION
Adds some missing fields that are useful for data analysis and other purposes.  The importance of etymology should be obvious.

Usernames are important when doing programatic analysis as they can act as an origin and quality signal.  For example "krtisfranks" indicates this is likely a math word, and "dalgimbehe" indicates the word came from a team effort. These are already public record, and these were included in the JVS dump.

(Sorry about the previous error; this project is difficult to test.)